### PR TITLE
Use Google Play Developer API v3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ addSbtPlugin( "org.scala-android" % "sbt-android" % "1.6.8" )
 githubProject := "sbt-googleplay"
 
 libraryDependencies ++=
-    "com.google.apis" % "google-api-services-androidpublisher" % "v2-rev31-1.22.0" ::
+    "com.google.apis" % "google-api-services-androidpublisher" % "v3-rev20191113-1.30.3" ::
     "com.google.oauth-client" % "google-oauth-client-jetty" % "1.22.0" ::
     Nil
 

--- a/src/main/scala/io/taig/sbt/googleplay/GooglePlayPlugin.scala
+++ b/src/main/scala/io/taig/sbt/googleplay/GooglePlayPlugin.scala
@@ -5,7 +5,7 @@ import java.util.Collections
 import android.AndroidPlugin
 import android.Keys._
 import com.google.api.client.http.FileContent
-import com.google.api.services.androidpublisher.model.{ LocalizedText, Track, TrackRelease }
+import com.google.api.services.androidpublisher.model.{LocalizedText, Track, TrackRelease}
 import sbt.Keys._
 import sbt._
 import sbt.complete.Parsers.spaceDelimited
@@ -13,132 +13,127 @@ import sbt.complete.Parsers.spaceDelimited
 import collection.JavaConverters._
 
 object GooglePlayPlugin extends AutoPlugin {
-    object autoImport extends Keys
 
-    import autoImport._
+  object autoImport extends Keys
 
-    override def requires = AndroidPlugin
+  import autoImport._
 
-    override def projectSettings: Seq[Def.Setting[_]] = Seq(
-        googlePlayApplication := {
-            val path = ( applicationId in Android ).value
-            val identifier = name.value
-            val version = ( versionName in Android ).value
+  override def requires = AndroidPlugin
 
-            s"$path-$identifier/$version"
-        },
-        googlePlayTrack := "beta",
-        googlePlayChangelog := Map.empty,
-        googlePlayServiceAccountEmail := {
-            sys.error {
-                """
-                  |Please specify your Google Play API service account email:
-                  |
-                  |googlePlayServiceAccountEmail := "12345678910@developer.gserviceaccount.com"
-                  |
-                  |You can set up a service account or find the email address in the Google Play
-                  |Developer Console (Settings > API access).
-                """.stripMargin.trim
-            }
-        },
-        googlePlayServiceAccountKey := {
-            sys.error {
-                """
-                  |Please specify your Google Play API service account key (P12 file):
-                  |
-                  |googlePlayServiceAccountKey := file( "./path/to/key.p12" )
-                  |
-                  |You can set up a service account or find the email address in the Google Play
-                  |Developer Console (Settings > API access).
-                """.stripMargin.trim
-            }
-        },
-        googlePlayPublish := googlePlayPublishApk.value( ( packageRelease in Android ).value ),
-        googlePlayPublishFile := {
-            val file = spaceDelimited( "<arg>" ).parsed match {
-                case Seq( file ) ⇒ new File( file )
-                case _ ⇒ sys.error {
-                    """
-                      |Invalid input arguments
-                      |Valid usage: googlePlayPublishFile file
-                      |  file: Path to APK file to publish
-                    """.stripMargin.trim
-                }
-            }
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    googlePlayApplication := {
+      val path = (applicationId in Android).value
+      val identifier = name.value
+      val version = (versionName in Android).value
 
-            googlePlayPublishApk.value( file )
-        },
-        googlePlayPublishApk := { file ⇒
-            if ( !file.exists() ) {
-                sys.error {
-                    s"""
-                      |APK file does not exist:
-                      |${file.getAbsolutePath}
-                    """.stripMargin.trim
-                }
-            }
-
-            val apkFile = new FileContent( "application/vnd.android.package-archive", file )
-
-            val service = Helper.authorize(
-                googlePlayApplication.value,
-                googlePlayServiceAccountEmail.value,
-                googlePlayServiceAccountKey.value
-            )
-
-            val packageName = ( applicationId in Android ).value
-
-            val edits = service.edits()
-
-            val insert = edits.insert( packageName, null ).execute()
-
-            val id = insert.getId
-
-            streams.value.log.info( "Uploading apk file ..." )
-
-            val apk = edits.apks().upload( packageName, id, apkFile ).execute()
-
-            val code = apk.getVersionCode
-
-            streams.value.log.info( s"Version code $code has been uploaded" )
-
-            val track = googlePlayTrack.value
-
-            streams.value.log.info( s"Adding apk to $track track" )
-
-            val changelogs = googlePlayChangelog.value.map {
-                case ( locale, changelog ) ⇒ new LocalizedText()
-                    .setLanguage( locale )
-                    .setText( changelog )
-            }
-
-            val apkVersionCodes = List( java.lang.Long.valueOf( apk.getVersionCode.toLong ) )
-            val updateTrackRequest = edits
-                .tracks
-                .update(
-                    packageName,
-                    id,
-                    track,
-                    new Track()
-                        .setReleases(
-                            Collections
-                                .singletonList(
-                                    new TrackRelease()
-                                        .setName( "My Beta Release" )
-                                        .setVersionCodes( apkVersionCodes.asJava )
-                                        .setStatus( "completed" )
-                                        .setReleaseNotes(
-                                            changelogs.toList.asJava
-                                        )
-                                )
-                        )
-                )
-            val updatedTrack = updateTrackRequest.execute
-            streams.value.log.info( String.format( "Track %s has been updated.", updatedTrack.getTrack ) )
-
-            streams.value.log.info( "Committing update!" )
-
-            edits.commit( packageName, id ).execute()
+      s"$path-$identifier/$version"
+    },
+    googlePlayTrack := "beta",
+    googlePlayChangelog := Map.empty,
+    googlePlayServiceAccountEmail := {
+      sys.error {
+        """
+          |Please specify your Google Play API service account email:
+          |
+          |googlePlayServiceAccountEmail := "12345678910@developer.gserviceaccount.com"
+          |
+          |You can set up a service account or find the email address in the Google Play
+          |Developer Console (Settings > API access).
+        """.stripMargin.trim
+      }
+    },
+    googlePlayServiceAccountKey := {
+      sys.error {
+        """
+          |Please specify your Google Play API service account key (P12 file):
+          |
+          |googlePlayServiceAccountKey := file( "./path/to/key.p12" )
+          |
+          |You can set up a service account or find the email address in the Google Play
+          |Developer Console (Settings > API access).
+        """.stripMargin.trim
+      }
+    },
+    googlePlayPublish := googlePlayPublishApk.value((packageRelease in Android).value),
+    googlePlayPublishFile := {
+      val file = spaceDelimited("<arg>").parsed match {
+        case Seq(file) ⇒ new File(file)
+        case _ ⇒ sys.error {
+          """
+            |Invalid input arguments
+            |Valid usage: googlePlayPublishFile file
+            |  file: Path to APK file to publish
+          """.stripMargin.trim
         }
-    )
+      }
+
+      googlePlayPublishApk.value(file)
+    },
+    googlePlayPublishApk := { file ⇒
+      if (!file.exists()) {
+        sys.error {
+          s"""
+             |APK file does not exist:
+             |${file.getAbsolutePath}
+                    """.stripMargin.trim
+        }
+      }
+
+      val apkFile = new FileContent("application/vnd.android.package-archive", file)
+
+      val service = Helper.authorize(
+        googlePlayApplication.value,
+        googlePlayServiceAccountEmail.value,
+        googlePlayServiceAccountKey.value
+      )
+
+      val packageName = (applicationId in Android).value
+
+      val edits = service.edits()
+
+      val insert = edits.insert(packageName, null).execute()
+
+      val id = insert.getId
+
+      streams.value.log.info("Uploading apk file ...")
+
+      val apk = edits.apks().upload(packageName, id, apkFile).execute()
+
+      val code = apk.getVersionCode
+
+      streams.value.log.info(s"Version code $code has been uploaded")
+
+      val track = googlePlayTrack.value
+
+      streams.value.log.info(s"Adding apk to $track track")
+
+      val changelogs = googlePlayChangelog.value.map {
+        case (locale, changelog) ⇒ new LocalizedText()
+          .setLanguage(locale)
+          .setText(changelog)
+      }
+
+      val apkVersionCodes = List(java.lang.Long.valueOf(apk.getVersionCode.toLong))
+      val updatedTracks = edits
+        .tracks
+        .update(
+          packageName,
+          id,
+          track,
+          new Track()
+            .setReleases(
+              Collections
+                .singletonList(
+                  new TrackRelease()
+                    .setVersionCodes(apkVersionCodes.asJava)
+                    .setReleaseNotes(changelogs.toList.asJava)
+                )
+            )
+        ).execute()
+      streams.value.log.info(String.format("Track %s has been updated.", updatedTracks.getTrack))
+      streams.value.log.info("Committing update!")
+
+      edits.commit(packageName, id).execute()
+    }
+  )
 }


### PR DESCRIPTION
As of 1 Dec 2019, Google Play Developer API versions 1 and 2 have been deprecated, requiring the use of version 3. 

Thank you to Gero (Empty2k12) for discovering and adding the specific changes that needed to be made. 

We will want to at least bump the minor version of the library after this change.